### PR TITLE
Request to remove links to google doc versions of Wave 1 specs

### DIFF
--- a/v1.1.0/index.html
+++ b/v1.1.0/index.html
@@ -40,37 +40,32 @@
                   <tr>
                     <td>Architecture and Nonfunctional Requirements</td>
                     <td><a href="https://www.govstack.global/wp-content/uploads/2022/03/Architecture_and_NonFunctional_Requirements_v1.1.0.pdf">PDF</a></td>
-                    <td><a href="https://docs.google.com/document/d/12b696fHlOAAHygFF5-XxUJkFyFjMIV99VDKZTXnnAkg/edit?usp=sharing">GOOGLE DOC (COMMENTS)</a></td>
+                    
                   </tr>
                   <tr>
                     <td>Security Requirements</td>
                     <td><a href="https://www.govstack.global/wp-content/uploads/2022/03/Security_Requirements_v1.1.0.pdf">PDF</a></td>
-                    <td><a href="https://docs.google.com/document/d/1Z9jS0BnfTM3azBED5349uD5sQ9VYYo8p/edit?usp=sharing&ouid=100386532413528832309&rtpof=true&sd=true">GOOGLE DOC (COMMENTS)</a></td>
+                    
                   </tr>
                   <tr>
                     <td>Information Mediator Building Block Specification</td>
                     <td><a href="https://www.govstack.global/wp-content/uploads/2022/03/Information_Mediator_Building_Block_Specification_v1.1.0.pdf">PDF</a></td>
-                    <td><a href="https://docs.google.com/document/d/1PhAUsLhQnVwqDjnkTIl9XXi7Yghtn1TlBvOEt2aoNEw/edit?usp=sharing">GOOGLE DOC (COMMENTS)</a></td>
                   </tr>
                   <tr>
                     <td>Registration Building Block Specification</td>
                     <td><a href="https://www.govstack.global/wp-content/uploads/2022/03/Registration_Building_Block_Specification_v1.1.0.pdf">PDF</a></td>
-                    <td><a href="https://docs.google.com/document/d/18aJLgW4dlB89UMFVXBnrzpHwGLnmQpaoxUGVMxsoGUo/edit?usp=sharing">GOOGLE DOC (COMMENTS)</a></td>
                   </tr>
                   <tr>
                     <td>Digital Registries Building Block Specification</td>
                     <td><a href="https://www.govstack.global/wp-content/uploads/2022/03/Digital_Registries_Building_Block_Specification_v1.1.0.pdf">PDF</a></td>
-                    <td><a href="https://docs.google.com/document/d/1mmSjpUmmztnJV2GliAg9eUA6f-WWyt7Wjey5otaX4Tw/edit?usp=sharing">GOOGLE DOC (COMMENTS)</a></td>
                   </tr>
                   <tr>
                     <td>Identity and Verification Building Block Specification</td>
                     <td><a href="https://www.govstack.global/wp-content/uploads/2022/03/Identity_and_Verification_Building_Block_Specification_v1.1.0.pdf">PDF</a></td>
-                    <td><a href="https://docs.google.com/document/d/1Fvt6Y6h2yd4JeoSNAZnemnQQqdOTlje3bA1bGnGXLcU/edit?usp=sharing">GOOGLE DOC (COMMENTS)</a></td>
                   </tr>
                   <tr>
                     <td>Payments Building Block Specification</td>
                     <td><a href="https://www.govstack.global/wp-content/uploads/2022/03/Payments_Building_Block_Specification_v1.1.0.pdf">PDF</a></td>
-                    <td><a href="https://docs.google.com/document/d/19r8J-2w1IRMNWqeeeBzO7oJ0GR9Nt-DX/edit?usp=sharing">GOOGLE DOC (COMMENTS)</a></td>
                   </tr>
             </table>
     </div>


### PR DESCRIPTION
Hey Max!
Can we please remove the links to google doc versions of Wave 1 bb specs. Just so there is no confusion for the TAC members.
Best regards
Ayush Shukla